### PR TITLE
Bug fixes: History Navigation

### DIFF
--- a/source/scripts/script.js
+++ b/source/scripts/script.js
@@ -97,6 +97,8 @@ function setupScript () {
   setupButtons();
 
   loadDay();
+  loadMonth();
+  loadYear();
 }
 
 /**

--- a/source/scripts/script.js
+++ b/source/scripts/script.js
@@ -56,11 +56,12 @@ window.onpopstate = function (event) {
   console.log('Current state.log: ' + event.state.view);
   switch (event.state.view) {
     case 'day':
+      transitionDaily();
       if (event.state.date) {
         currDate = event.state.date;
         loadDay();
+        updateIndex();
       }
-      transitionDaily();
       break;
     case 'month':
       if (event.state.date) {
@@ -556,7 +557,7 @@ export function updateEntries (currID = IDConverter.generateID('day', currDate),
   } else if (entries[index] !== currID) {
     entries.splice(index, 0, currID);
   } else {
-    console.error(`updateEntries unnecessarily called for ID ${currID} at index ${index}`);
+    console.log(`updateEntries has already been called for ID ${currID} at index ${index}`);
   }
 }
 /* For quick commenting out of code */


### PR DESCRIPTION
History navigation bugs noticed:
- Entry navigation buttons weren't being set (<<) (>>)
- When reloading page, using navigation buttons to month/year resulted in blank pages

Understanding/Fixing:
- Entry buttons are set in `updateIndex` which wasn't called inside the `window.onpopstate` for navigation into daily
  - Small note: moved the `transitionDaily` up, since it auto toggles both entry buttons on
  - I recall having an issue with `transition` functions being called before `load` functions but forgot what the issues were
  - No visible bugs from this fix but I wouldn't be surprised if some popped up
- Month/Year `load` functions are only called when user clicks on the `zoomOut` button/icon
  - Fixed by calling all 3 `load` functions in `setupScript`, which thankfully only loads data (`transition` functions handle the visibility toggling)