### PR TITLE
Refactoring: Tooltips on hover

### DIFF
--- a/source/HTML/log.html
+++ b/source/HTML/log.html
@@ -8,7 +8,6 @@
         <!-- Main Stylesheet -->
         <link rel="stylesheet" href="../style/style.css">
         <link rel="stylesheet" href="../assets/css/all.css">
-        <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css">
         <link href="https://fonts.googleapis.com/css2?family=Kaushan+Script&display=swap" rel="stylesheet">
     </head>
     <body>
@@ -206,8 +205,6 @@
                 </div>
 
             </main>
-            <script src="https://code.jquery.com/jquery-latest.min.js"></script>
-            <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.4.1/js/bootstrap.min.js"></script>
             <script src="../scripts/chart.min.js"></script>
             <script type="module" src="../classes/daily-log.js"></script>
             <script type="module" src="../classes/monthly-log.js"></script>

--- a/source/classes/bullet.js
+++ b/source/classes/bullet.js
@@ -136,6 +136,35 @@ class BulletEntry extends HTMLElement {
           border: none;
           background-color: transparent;
         }
+
+        .tooltip {
+          display: inline;
+          position: relative;
+        }
+
+        .tooltip:hover::after {
+          background: #333;
+          background: rgba(0, 0, 0, 0.8);
+          border-radius: 5px;
+          bottom: 26px;
+          color: #fff;
+          content: attr(tooltip);
+          left: -85%;
+          padding: 5px 15px;
+          position: absolute;
+          z-index: 98;
+        }
+
+        .tooltip:hover::before {
+          border: solid;
+          border-color: #333 transparent;
+          border-width: 6px 6px 0 6px;
+          bottom: 20px;
+          content: "";
+          left: 20%;
+          position: absolute;
+          z-index: 99;
+        }
         
         [contenteditable] {
           outline: 0px solid transparent;
@@ -568,10 +597,10 @@ class BulletEntry extends HTMLElement {
   createLabel (labelName) {
     // Create button and set attributes (for CSS and other logic) + apply a tooltip (on hoever, show labelName)
     const button = document.createElement('button');
-    button.className = 'label';
+    button.classList.add('label');
+    button.classList.add('tooltip');
     button.id = labelName;
-    $(button).tooltip();
-    button.title = labelName;
+    button.setAttribute('tooltip', labelName);
 
     // Create icon that will go inside the button (image of the lable), color based off labelName and labels (from script!)
     const icon = document.createElement('i');


### PR DESCRIPTION
Bootstrap's CSS was messing with the button disabled (and who knows what else was bugging out) so I removed it.

The only thing we were using it for was displaying tooltips, so I figured out a native way to handle that.

Also we're not using jQuery and Bootstrap anywhere else so I removed their imports. 